### PR TITLE
Correctly handle symbolic links to directories

### DIFF
--- a/src/fileItem.ts
+++ b/src/fileItem.ts
@@ -7,6 +7,7 @@ const icons = {
   [FileType.File]: "$(file)",
   [FileType.Directory]: "$(file-directory)",
   [FileType.SymbolicLink]: "$(file-symlink-file)",
+  [FileType.SymbolicLink | FileType.Directory]: "$(file-symlink-directory)",
   [FileType.Unknown]: "$(file)",
 };
 


### PR DESCRIPTION
`FileType` is a bitmask, e.g., `66` is `64 | 2` aka a symlink *and* a directory.

It would be great if you could merge and publish a new version with this fix!

Thanks for porting this from Atom. I was an avid Atom user and this extension is an absolute must for me.