### PR TITLE
Fix to set focus on input when showing picker

### DIFF
--- a/src/advancedOpenFile.ts
+++ b/src/advancedOpenFile.ts
@@ -14,13 +14,10 @@ export class AdvancedOpenFile {
   }
 
   async pick() {
-    this.picker.enabled = false;
     this.show();
 
     this.picker.value = this.currentPath.fsPath;
     this.picker.items = await createFileItems(this.currentPath.fsPath);
-
-    this.picker.enabled = true;
   }
 
   initPicker(): QuickPick<FileItem> {


### PR DESCRIPTION
After upgrading VsCode to v1.73.0, the selected list is in focus when opening picker.

This PR solves the above problem

Perhaps related to https://github.com/microsoft/vscode/pull/163739

Because there is no need to set enabled false, deleted releated codes.