### PR TITLE
Prompt workspace picker if file does not exist

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+import * as fs from "fs";
 import * as Path from "path";
 import * as vscode from "vscode";
 import { commands, ExtensionContext, WorkspaceFolder, Uri } from "vscode";
@@ -16,7 +17,9 @@ async function pickWorkspace(): Promise<string> {
 async function pathToCurrentDirectory(): Promise<string> {
   const currentEditor = vscode.window.activeTextEditor;
   if (currentEditor) {
-    return Path.dirname(currentEditor.document.uri.path);
+    if (fs.existsSync(currentEditor.document.uri.path)) {
+      return Path.dirname(currentEditor.document.uri.path);
+    }
   }
 
   return pickWorkspace();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,11 +17,14 @@ async function pickWorkspace(): Promise<string> {
 async function pathToCurrentDirectory(): Promise<string> {
   const currentEditor = vscode.window.activeTextEditor;
   if (currentEditor) {
-    if (fs.existsSync(currentEditor.document.uri.path)) {
+    try {
+      // If the uri does not exist, it raises an exception.
+      await vscode.workspace.fs.stat(currentEditor.document.uri);
       return Path.dirname(currentEditor.document.uri.path);
+    } catch {
+      // Ignore the error from fs.stat and return pickWorkspace();
     }
   }
-
   return pickWorkspace();
 }
 


### PR DESCRIPTION
The URI of the text editor does not a valid for sometimes.
For example, an [`edamagit`](https://github.com/kahole/edamagit/blob/52546589349022a73bf3556cc348c10deb9d3a47/src/views/magitStatusView.ts#L25) view uses `status.magit` as the uri.

In those cases, this patch shows a picker to choose workspaces rather than showing some invalid paths.

https://github.com/user-attachments/assets/8c0d6bcc-2b09-47b4-8b05-5bd0510f1547


